### PR TITLE
Fixed inconsistent injection bug

### DIFF
--- a/package/Editor/MissingComponentHelper.cs
+++ b/package/Editor/MissingComponentHelper.cs
@@ -74,13 +74,18 @@ namespace Needle.ComponentExtension
 				if (prop != null)
 				{
 					var identifier = editor.target.GetType().AssemblyQualifiedName;
-					if (identifier != null && !prop.stringValue.StartsWith(identifier))
+					identifier = string.Join(",", identifier.Split(',').Take(2));
+
+					if (!String.IsNullOrEmpty(identifier) && (String.IsNullOrEmpty(prop.stringValue) || !prop.stringValue.StartsWith(identifier)))
 					{
-						identifier = string.Join(",", identifier.Split(',').Take(2));
 						var id = GlobalObjectId.GetGlobalObjectIdSlow(editor.target);
 						prop.stringValue = $"{identifier} $ " + id;
 						serializedObject.ApplyModifiedProperties();
 						EditorUtility.SetDirty(editor.target);
+
+						// Debug.Log("<color=green>Injected!</color>");
+					} else {
+						// Debug.Log("<color=yellow>Skipped!</color>");
 					}
 				}
 				return;


### PR DESCRIPTION
Moved the 'identifier' property trimming function to before the compare because otherwise StartsWith not working correctly and causing injection on every frame, also causing minor annoyance with setting the scene dirty every time you click on a object with script.


Added null check for prop.stringValue because the String.StartsWith method returns true when prop.stringValue is empty, which is not the intended behaviour.